### PR TITLE
Fix build script fallback for runtime-benchmarks

### DIFF
--- a/automated_deploy.sh
+++ b/automated_deploy.sh
@@ -114,7 +114,10 @@ build_parachain() {
     cargo clean
     
     # Build runtime and node
-    cargo build --release --features runtime-benchmarks
+    # Some builds may not provide the optional `runtime-benchmarks` feature.
+    # Attempt to build with it first and fall back to a normal release build
+    # if the feature is unavailable.
+    cargo build --release --features runtime-benchmarks || cargo build --release
     
     if [ ! -f "./target/release/aivectormp-node" ]; then
         log_error "Parachain build failed"


### PR DESCRIPTION
## Summary
- handle missing `runtime-benchmarks` feature in deployment script

## Testing
- `bash -n automated_deploy.sh`

------
https://chatgpt.com/codex/tasks/task_e_68531d4b1f30832d887c495d2462045b