### PR TITLE
Fix missing Rust library entry point

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "ai_vector_blockchain_contracts"
+version = "1.0.0"
+authors = ["AI Vector Blockchain Team"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+[lib]
+name = "ai_vector_blockchain_contracts"
+path = "lib.rs"
+crate-type = [
+    # Used for normal contract Wasm blobs.
+    "cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+overflow-checks = true
+
+# The following profiles are used for cross-contract calls
+[profile.release.package.dataset_registry]
+codegen-units = 1
+
+[profile.release.package.payment_manager]
+codegen-units = 1
+
+[profile.release.package.zk_verifier]
+codegen-units = 1

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use dataset_registry::*;
+pub use payment_manager::*;
+pub use zk_verifier::*;
+
+mod dataset_registry;
+mod payment_manager;
+mod zk_verifier;


### PR DESCRIPTION
## Summary
- add library entry point at `lib.rs`
- provide `Cargo.toml` so the crate can build as a library

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68532211f98c832da944d15f88c016f4