### PR TITLE
Fix ink derive imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["AI Vector Blockchain Team"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { version = "5.0.0", default-features = false, features = ["std", "derive"] }
 
 [lib]
 name = "ai_vector_blockchain_contracts"

--- a/cargo_toml.txt
+++ b/cargo_toml.txt
@@ -5,7 +5,7 @@ authors = ["AI Vector Blockchain Team"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { version = "5.0.0", default-features = false, features = ["std", "derive"] }
 
 [lib]
 name = "ai_vector_blockchain_contracts"


### PR DESCRIPTION
## Summary
- enable `derive` feature on ink dependency to provide SpreadLayout and PackedLayout

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68532ae20fa0832d8eac55f4380c2b24